### PR TITLE
Add bind_unbound_port: necessary for device frontends

### DIFF
--- a/lib/eventchn.ml
+++ b/lib/eventchn.ml
@@ -23,6 +23,7 @@ type t = int
 
 external notify: handle -> int -> unit = "stub_eventchn_notify"
 external bind_interdomain: handle -> int -> int -> int = "stub_eventchn_bind_interdomain"
+external bind_unbound_port: handle -> int -> int = "stub_eventchn_bind_unbound_port"
 external bind_dom_exc_virq: handle -> int = "stub_eventchn_bind_dom_exc_virq"
 external unbind: handle -> int -> unit = "stub_eventchn_unbind"
 external pending: handle -> int = "stub_eventchn_pending"

--- a/lib/eventchn.mli
+++ b/lib/eventchn.mli
@@ -44,6 +44,11 @@ val bind_interdomain : handle -> int -> int -> t
     channel connected to domid:remote_port. On error it will
     throw a Failure exception. *)
 
+val bind_unbound_port : handle -> int -> t
+(** [bind_unbound_port h remote_domid] returns a new event channel
+    awaiting an interdomain connection from [remote_domid]. On error
+    it will throw a Failure exception. *)
+
 val bind_dom_exc_virq : handle -> t
 (** Binds a local event channel to the VIRQ_DOM_EXC
     (domain exception VIRQ). On error it will throw a Failure

--- a/lib/eventchn_stubs.c
+++ b/lib/eventchn_stubs.c
@@ -90,6 +90,20 @@ CAMLprim value stub_eventchn_bind_interdomain(value xce, value domid,
 	CAMLreturn(port);
 }
 
+CAMLprim value stub_eventchn_bind_unbound_port(value xce, value remote_domid)
+{
+	CAMLparam2(xce, remote_domid);
+	CAMLlocal1(port);
+	evtchn_port_or_error_t rc;
+
+	rc = xc_evtchn_bind_unbound_port(_H(xce), Int_val(remote_domid));
+	if (rc == -1)
+		caml_failwith("evtchn bind_unbound_port failed");
+	port = Val_int(rc);
+
+	CAMLreturn(port);
+}
+
 CAMLprim value stub_eventchn_bind_dom_exc_virq(value xce)
 {
 	CAMLparam1(xce);


### PR DESCRIPTION
A frontend will typically bind an 'unbound' port which is set to
await an interdomain connection from a specific remote domid
(the backend).
