### PR TITLE
Work around unknown 'unknown' shutdown reasons

### DIFF
--- a/xenlight/xenlight_stubs.c
+++ b/xenlight/xenlight_stubs.c
@@ -792,7 +792,9 @@ static int shutdown_reason_val (libxl_ctx *ctx, libxl_shutdown_reason *c_val, va
 
 	switch(Int_val(v)) {
 #ifdef OCAML_READY
-	    case 0: *c_val = LIBXL_SHUTDOWN_REASON_UNKNOWN; break;
+	    case 0:
+	    case -1:
+	    case -255: *c_val = LIBXL_SHUTDOWN_REASON_UNKNOWN; break;
 #endif
 	    case 1: *c_val = LIBXL_SHUTDOWN_REASON_POWEROFF; break;
 	    case 2: *c_val = LIBXL_SHUTDOWN_REASON_REBOOT; break;


### PR DESCRIPTION
This should probably be fixed in libxl, consider this a workaround.

Although xen uses -1 as an 'unknown' shutdown reason, when this
is marshalled into a getdomaininfo domctl, it is masked with 0xff
and treated as an unsigned value.

Signed-off-by: David Scott dave.scott@eu.citrix.com
