### PR TITLE
Make the semantics of Activations more like Mirage-Xen

### DIFF
--- a/lib/eventchn_stubs.c
+++ b/lib/eventchn_stubs.c
@@ -37,20 +37,26 @@
 
 #define _H(__h) ((xc_evtchn *)(__h))
 
+xc_interface *global_xce = NULL;
+
 CAMLprim value stub_eventchn_init(value unit)
 {
   CAMLparam1(unit);
-  xc_interface *xce = xc_evtchn_open(NULL, XC_OPENFLAG_NON_REENTRANT);
+  if (global_xce == NULL) {
+    global_xce = xc_evtchn_open(NULL, XC_OPENFLAG_NON_REENTRANT);
+  }
 
-  if (xce == NULL)
+  if (global_xce == NULL)
     caml_failwith(strerror(errno));
 
-  CAMLreturn((value)xce);
+  CAMLreturn((value)global_xce);
 }
 
 CAMLprim value stub_eventchn_close(value xce)
 {
-  return Val_int(xc_evtchn_close(_H(xce)));
+/*  return Val_int(xc_evtchn_close(_H(xce))); */
+/* We don't ever actually want to do this */
+  return(Val_int(0));
 }
 
 CAMLprim value stub_eventchn_fd(value xce)

--- a/lwt/activations.ml
+++ b/lwt/activations.ml
@@ -17,7 +17,7 @@ let wake port =
 
 (* Go through the event mask and activate any events, potentially spawning
    new threads *)
-let run xe =
+let run_real xe =
   let fd = Lwt_unix.of_unix_file_descr ~blocking:false ~set_flags:true (Eventchn.fd xe) in
   let rec inner () =
     lwt () = Lwt_unix.wait_read fd in
@@ -26,3 +26,9 @@ let run xe =
     Eventchn.unmask xe port;
     inner ()
   in inner ()
+
+let activations_thread = run_real (Eventchn.init ())
+
+(* Here for backwards compatibility *)
+let run _ = ()
+

--- a/lwt/activations.mli
+++ b/lwt/activations.mli
@@ -20,6 +20,6 @@ val wait : Eventchn.t -> unit Lwt.t
 (** For a given event channel, create a thread which completes when
     the event channel is signalled. *)
 
-val run : Eventchn.handle -> unit Lwt.t
+val run : Eventchn.handle -> unit
 (** Start a background thread which monitors the state of every event
     channel and wakes up any sleeping threads. *)

--- a/test/test_events.ml
+++ b/test/test_events.ml
@@ -4,9 +4,6 @@ let main () =
   (* Obtain a handler. *)
   let evtchn_h = Eventchn.init () in
 
-  (* Run the activation loop in the background. *)
-  Lwt.async (fun () -> Activations.run evtchn_h);
-
   (* Create two connected event channels. *)
   let ch1 = Eventchn.bind_unbound_port evtchn_h 0 in
   let ch2 = Eventchn.bind_interdomain evtchn_h 0 (Eventchn.to_int ch1) in


### PR DESCRIPTION
A user of this library would never want to call Activations.run -
Mirage-Xen runs this automatically, and so we do here as well now.

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
