### PR TITLE
configure: remove dependency on configure from config.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BINDIR?=/usr/lib/xcp/lib
 J=4
 
 include config.mk
-config.mk: configure
+config.mk:
 	echo Please re-run configure
 	exit 1
 


### PR DESCRIPTION
In some environments this just doesn't work (perhaps because of timestamps
in tmpfs filesystems)

Signed-off-by: David Scott dave.scott@citrix.com
