### PR TITLE
XenServer/Xen-4.6 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ build: setup.data setup.bin
 ifeq ($(ENABLE_XENGUEST44),true)
 	(cd xenguest-4.4 && make)
 endif
+ifeq ($(ENABLE_XENGUEST46),true)
+	(cd xenguest-4.6 && make)
+endif
 
 doc: setup.data setup.bin
 	@./setup.bin -doc -j $(J)
@@ -41,6 +44,9 @@ endif
 ifeq ($(ENABLE_XENGUEST44),true)
 	(cd xenguest-4.4 && make install BINDIR=$(BINDIR))
 endif
+ifeq ($(ENABLE_XENGUEST46),true)
+	(cd xenguest-4.6 && make install BINDIR=$(BINDIR))
+endif
 
 test: setup.bin build
 	@./setup.bin -test
@@ -52,6 +58,9 @@ reinstall: setup.bin
 ifeq ($(ENABLE_XENGUEST44),true)
 	(cd xenguest-4.4 && make install BINDIR=$(BINDIR))
 endif
+ifeq ($(ENABLE_XENGUEST46),true)
+	(cd xenguest-4.6 && make install BINDIR=$(BINDIR))
+endif
 
 uninstall:
 	@ocamlfind remove xenctrl || true
@@ -60,10 +69,16 @@ uninstall:
 ifeq ($(ENABLE_XENGUEST44),true)
 	(cd xenguest-4.4 && make uninstall BINDIR=$(BINDIR))
 endif
+ifeq ($(ENABLE_XENGUEST46),true)
+	(cd xenguest-4.6 && make uninstall BINDIR=$(BINDIR))
+endif
 
 clean:
 	@ocamlbuild -clean
 	@rm -f setup.data setup.log setup.bin
 ifeq ($(ENABLE_XENGUEST44),true)
 	(cd xenguest-4.4 && make clean)
+endif
+ifeq ($(ENABLE_XENGUEST46),true)
+	(cd xenguest-4.6 && make clean)
 endif

--- a/configure.ml
+++ b/configure.ml
@@ -187,7 +187,7 @@ let configure verbose disable_xenctrl disable_xenlight disable_xenguest =
   if not xenlight_4_4 then begin
     Printf.fprintf stderr "Failure: we can't build anything without libxl from Xen 4.4 or greater\n";
     exit 1;
-  end
+  end;
   (try Unix.unlink "xenlight" with Unix.Unix_error(Unix.ENOENT, _, _) -> ());
   Unix.symlink ("xenlight-" ^ (if xen_4_5 then "4.5" else "4.4")) "xenlight";
  

--- a/lib/xenctrl.ml
+++ b/lib/xenctrl.ml
@@ -259,6 +259,13 @@ external version_changeset: handle -> string = "stub_xc_version_changeset"
 external version_capabilities: handle -> string =
   "stub_xc_version_capabilities"
 
+type featureset_index = Featureset_raw | Featureset_host | Featureset_pv | Featureset_hvm
+external get_cpu_featureset : handle -> featureset_index -> int64 array = "stub_xc_get_cpu_featureset"
+external get_featureset : handle -> featureset_index -> int64 array = "stub_xc_get_cpu_featureset"
+
+external upgrade_oldstyle_featuremask: handle -> int64 array -> bool -> int64 array = "stub_upgrade_oldstyle_featuremask"
+external oldstyle_featuremask: handle -> int64 array = "stub_oldstyle_featuremask"
+
 external watchdog : handle -> int -> int32 -> int
   = "stub_xc_watchdog"
 

--- a/lib/xenctrl.mli
+++ b/lib/xenctrl.mli
@@ -190,6 +190,12 @@ external domain_get_pfn_list : handle -> domid -> nativeint -> nativeint array =
 (** DEPRECATED.  Avoid using this, as it does not correctly account
     for PFNs without a backing MFN. *)
 
+type featureset_index = Featureset_raw | Featureset_host | Featureset_pv | Featureset_hvm
+external get_cpu_featureset : handle -> featureset_index -> int64 array = "stub_xc_get_cpu_featureset"
+external get_featureset : handle -> featureset_index -> int64 array = "stub_xc_get_cpu_featureset"
+
+external upgrade_oldstyle_featuremask: handle -> int64 array -> bool -> int64 array = "stub_upgrade_oldstyle_featuremask"
+external oldstyle_featuremask: handle -> int64 array = "stub_oldstyle_featuremask"
 
 
 (** {3 Domain lifecycle ops} *)

--- a/lib/xenctrl_stubs.c
+++ b/lib/xenctrl_stubs.c
@@ -808,7 +808,11 @@ CAMLprim value stub_xc_domain_cpuid_apply_policy(value xch, value domid)
 #if defined(__i386__) || defined(__x86_64__)
 	int r;
 
-	r = xc_cpuid_apply_policy(_H(xch), _D(domid));
+	r = xc_cpuid_apply_policy(_H(xch), _D(domid)
+#ifdef XEN_SYSCTL_cpu_featureset_raw
+				  ,NULL,0
+#endif
+				  );
 	if (r < 0)
 		failwith_xc(_H(xch));
 #else

--- a/opam
+++ b/opam
@@ -1,5 +1,9 @@
-opam-version: "1"
-maintainer: "dave.scott@eu.citrix.com"
+opam-version: "1.2"
+maintainer: "jonathan.ludlam@citrix.com"
+authors: "xen-devel@lists.xen.org"
+homepage: "http://www.xenproject.org/"
+bug-reports: "xen-devel@lists.xen.org"
+dev-repo: "git://github.com/xapi-project/ocaml-xen-lowlevel-libs"
 tags: [
   "org:mirage"
   "org:xapi-project"
@@ -7,6 +11,8 @@ tags: [
 build: [
   ["./configure"]
   [make]
+]
+install: [
   [make "install" "BINDIR=%{bin}%"]
 ]
 remove: [
@@ -24,4 +30,5 @@ depexts: [
   [["centos"] ["xen-devel"]]
   [["xenserver"] ["xen-dom0-libs-devel" "xen-libs-devel"]]
 ]
-ocaml-version: [>= "4.00.0"]
+available: [ ocaml-version >= "4.00.0" ]
+

--- a/xenguest-4.6/xenguest_stubs.c
+++ b/xenguest-4.6/xenguest_stubs.c
@@ -61,22 +61,6 @@ void xc_dom_release(struct xc_dom_image *dom);
 char *xs_domain_path = NULL;
 char *pci_passthrough_sbdf_list = NULL;
 
-#define XC_DOM_DECOMPRESS_MAX (1024*1024*1024) 
-#define ADDR (*(volatile int *) addr)
-
-static inline void clear_bit(int nr, volatile void *addr)
-{
-    asm volatile ( "lock; btrl %1,%0"
-                   : "+m" (ADDR) : "Ir" (nr) : "memory");
-}
-#define clear_bit(nr, addr) ({                          \
-    if ( bitop_bad_size(addr) ) __bitop_bad_size();     \
-    clear_bit(nr, addr);                                \
-})
-extern void __bitop_bad_size(void);
-#define bitop_bad_size(addr) (sizeof(*(addr)) < 4)
-
-
 /* The following boolean flags are all set by their value
    in the platform area of xenstore. The only value that
    is considered true is the string 'true' */

--- a/xenguest-4.6/xenguest_stubs.c
+++ b/xenguest-4.6/xenguest_stubs.c
@@ -45,14 +45,11 @@ int xc_dom_gnttab_seed(xc_interface *xch, domid_t domid,
 int xc_dom_kernel_max_size(struct xc_dom_image *dom, size_t sz);
 int xc_dom_ramdisk_max_size(struct xc_dom_image *dom, size_t sz);
 void xc_dom_release(struct xc_dom_image *dom);
+#define XC_DOM_DECOMPRESS_MAX (1024*1024*1024)
 
 #include <xen/hvm/hvm_info_table.h>
 #include <xen/hvm/params.h>
 #include <xen/hvm/e820.h>
-
-#ifdef XEN_SYSCTL_cpu_featureset_raw
-#include <xen/arch-x86/featureset.h>
-#endif
 
 #include "xg_internal.h"
 /*
@@ -166,115 +163,14 @@ int xenstore_puts(const char *key, const char *val)
 
 static uint32_t *featureset, nr_features;
 
-/*
- * Choose the featureset to use for a VM.
- *
- * The toolstack is expected to provide a featureset in the
- * platform/featureset xenstore key, fomatted as a bitmap of '-' delimited
- * 32bit hex-encoded words.  e.g.
- *
- *   aaaaaaaa-bbbbbbbb-cccccccc
- *
- * If no featureset is found, default to the host maximum.  It is important in
- * a heterogenous case to permit featuresets longer than this hosts maximum,
- * if they have been zero-extended to make a common longest length.
- */
 static int get_vm_featureset(bool hvm)
 {
-#ifdef XEN_SYSCTL_cpu_featureset_raw
-    char *platform = xenstore_gets("platform/featureset");
-    char *s = platform, *e;
-    unsigned int i = 0;
-    int rc = 0;
-
-    if ( !platform )
-    {
-        xg_info("No featureset provided - using host maximum\n");
-
-        return xc_get_cpu_featureset(xch,
-                                     hvm ? XEN_SYSCTL_cpu_featureset_hvm
-                                         : XEN_SYSCTL_cpu_featureset_pv,
-                                     &nr_features, featureset);
-    }
-    else
-        xg_info("Parsing '%s' as featureset\n", platform);
-
-    while ( *s != '\0' )
-    {
-        unsigned long val;
-
-        errno = 0;
-        val = strtoul(s, &e, 16);
-        if ( (errno != 0) ||            /* Error converting. */
-             (val > ~(uint32_t)0) ||    /* Value out of range. */
-             (e == s) ||                /* No digits found. */
-                                        /* Bad following characters. */
-             !(*e == '\0' || *e == '-' || *e == ':')
-            )
-        {
-            xg_err("Bad '%s' in featureset\n", s);
-            rc = -1;
-            break;
-        }
-
-        if ( i < nr_features )
-            featureset[i++] = val;
-        else if ( val != 0 )
-        {
-            xg_err("Requested featureset '%s' truncated on this host\n", platform);
-            rc = -1;
-            break;
-        }
-
-        s = e;
-        if ( *s == '-' || *s == ':' )
-            s++;
-    }
-
-    free(platform);
-    return rc;
-#else
     return 0;
-#endif
 }
 
 int construct_cpuid_policy(const struct flags *f, bool hvm)
 {
-#ifdef XEN_SYSCTL_cpu_featureset_raw
-    int rc = -1;
-
-    if ( xc_get_cpu_featureset(xch,
-                               XEN_SYSCTL_cpu_featureset_host,
-                               &nr_features, NULL) ||
-         nr_features == 0 )
-    {
-        xg_err("Failed to obtain featureset size %d %s\n",
-               errno, strerror(errno));
-        goto out;
-    }
-
-    featureset = calloc(nr_features, sizeof(*featureset));
-    if ( !featureset )
-    {
-        xg_err("Failed to allocate memory for featureset\n");
-        goto out;
-    }
-
-    if ( get_vm_featureset(hvm) )
-        goto out;
-
-    if ( !f->nx )
-        clear_bit(X86_FEATURE_NX, featureset);
-
-    rc = xc_cpuid_apply_policy(xch, domid, featureset, nr_features);
-
- out:
-    free(featureset);
-    featureset = NULL;
-    return rc;
-#else
     return 0;
-#endif
 }
 
 static int hvmloader_flag(const char *key)
@@ -282,7 +178,7 @@ static int hvmloader_flag(const char *key)
     /* Params going to hvmloader need to convert "true" -> '1' as Xapi gets
      * this wrong when migrating from older hosts. */
 
-    char *val = xenstore_gets(key);
+    char *val = xenstore_gets("%s",key);
     int ret = -1;
 
     if ( val )

--- a/xenguest-4.6/xenguest_stubs.c
+++ b/xenguest-4.6/xenguest_stubs.c
@@ -207,10 +207,10 @@ static int get_vm_featureset(bool hvm)
     {
         xg_info("No featureset provided - using host maximum\n");
 
-        return xc_get_featureset(xch,
-                                 hvm ? XEN_SYSCTL_featureset_hvm
-                                     : XEN_SYSCTL_featureset_pv,
-                                 &nr_features, featureset);
+        return xc_get_cpu_featureset(xch,
+                                     hvm ? XEN_SYSCTL_cpu_featureset_hvm
+                                         : XEN_SYSCTL_cpu_featureset_pv,
+                                     &nr_features, featureset);
     }
     else
         xg_info("Parsing '%s' as featureset\n", platform);
@@ -259,9 +259,9 @@ int construct_cpuid_policy(const struct flags *f, bool hvm)
 #ifdef XEN_SYSCTL_cpu_featureset_raw
     int rc = -1;
 
-    if ( xc_get_featureset(xch,
-                           XEN_SYSCTL_featureset_host,
-                           &nr_features, NULL) ||
+    if ( xc_get_cpu_featureset(xch,
+                               XEN_SYSCTL_cpu_featureset_host,
+                               &nr_features, NULL) ||
          nr_features == 0 )
     {
         xg_err("Failed to obtain featureset size %d %s\n",
@@ -282,8 +282,7 @@ int construct_cpuid_policy(const struct flags *f, bool hvm)
     if ( !f->nx )
         clear_bit(X86_FEATURE_NX, featureset);
 
-    rc = xc_cpuid_apply_policy_with_featureset(xch, domid,
-                                               featureset, nr_features);
+    rc = xc_cpuid_apply_policy(xch, domid, featureset, nr_features);
 
  out:
     free(featureset);


### PR DESCRIPTION
Allows trunk xenopsd to be built against this repo. Xenopsd will have to put some exception handlers around the cpu features calls to cope with them being unimplemented.