### PR TITLE
Update opam and Travis configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,12 @@
 language: c
-sudo: false
-services:
-  - docker
+sudo: required
+service: docker
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
-script: bash ./.travis-docker.sh
+script: bash -ex .travis-docker.sh
 env:
- global:
-   - PACKAGE="xenctrl"
- matrix:
-   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.03
-   - DISTRO=debian-stable OCAML_VERSION=4.04
-   # xen-devel is not available in the default CentOs repo and we cannot get it
-   # using PRE_INSTALL_HOOK because that is run after "opam depext":
-   # - DISTRO=centos-7 OCAML_VERSION=4.05
-   - DISTRO=debian-testing OCAML_VERSION=4.06
-   - DISTRO=fedora-29 OCAML_VERSION=4.07
+  global:
+    - PACKAGE="xenctrl"
+    - PINS="xenctrl:."
+    - BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
+  matrix:
+    - DISTRO="debian-9-ocaml-4.07"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-sudo: required
+sudo: false
 service: docker
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
 script: bash -ex .travis-docker.sh

--- a/xenctrl.opam
+++ b/xenctrl.opam
@@ -24,6 +24,7 @@ depends: [
   "ocamlfind" {build}
   "lwt" {with-test}
   "cmdliner" {build}
+  "ocamlbuild"
 ]
 depexts: [
   ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}


### PR DESCRIPTION
* Add missing dependency on "ocamlbuild"
* Update Travis

Travis builds were failing on some distributions because Xen 4.11 is not yet supported by this package. Travis now uses a distribution with Xen 4.7.6.