### PR TITLE
Drop get_featureset

### DIFF
--- a/lib/xenctrl.ml
+++ b/lib/xenctrl.ml
@@ -248,7 +248,6 @@ external version_capabilities: handle -> string =
 
 type featureset_index = Featureset_raw | Featureset_host | Featureset_pv | Featureset_hvm
 external get_cpu_featureset : handle -> featureset_index -> int64 array = "stub_xc_get_cpu_featureset"
-external get_featureset : handle -> featureset_index -> int64 array = "stub_xc_get_cpu_featureset"
 
 external upgrade_oldstyle_featuremask: handle -> int64 array -> bool -> int64 array = "stub_upgrade_oldstyle_featuremask"
 external oldstyle_featuremask: handle -> int64 array = "stub_oldstyle_featuremask"

--- a/lib/xenctrl.mli
+++ b/lib/xenctrl.mli
@@ -188,7 +188,6 @@ external map_foreign_range : handle -> domid -> int -> nativeint -> Xenmmap.mmap
 
 type featureset_index = Featureset_raw | Featureset_host | Featureset_pv | Featureset_hvm
 external get_cpu_featureset : handle -> featureset_index -> int64 array = "stub_xc_get_cpu_featureset"
-external get_featureset : handle -> featureset_index -> int64 array = "stub_xc_get_cpu_featureset"
 
 external upgrade_oldstyle_featuremask: handle -> int64 array -> bool -> int64 array = "stub_upgrade_oldstyle_featuremask"
 external oldstyle_featuremask: handle -> int64 array = "stub_oldstyle_featuremask"


### PR DESCRIPTION
It is an alias of get_cpu_featureset, and all users have been cleaned up.

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>